### PR TITLE
Support EXPOSE with SCTP protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - optionally flag WORKDIR instructions that do not point to an absolute path ([#47](https://github.com/rcjsuen/dockerfile-utils/issues/47))
   - `ValidationCode.WORKDIR_IS_NOT_ABSOLUTE`
   - `ValidatorSettings.instructionWorkdirRelative`
+- add support for SCTP in EXPOSE instruction ([#52](https://github.com/rcjsuen/dockerfile-utils/issues/52))
 
 ### Fixed
 - fix incorrect validation of ENV and LABEL instructions with many quoted properties on mulitple lines ([#50](https://github.com/rcjsuen/dockerfile-utils/issues/50))

--- a/bin/dockerfile-utils
+++ b/bin/dockerfile-utils
@@ -41,7 +41,7 @@ if (args.length === 0 || args[0] === "-h" || args[0] === "--help") {
 
 function printVersion() {
     const package = require("../package.json");
-    console.log("dockerfile-utils version " + package.version + " (supports Docker CE 17.09)");
+    console.log("dockerfile-utils version " + package.version + " (supports Docker CE 18.03)");
 }
 
 function printHelp() {

--- a/src/dockerValidator.ts
+++ b/src/dockerValidator.ts
@@ -592,7 +592,7 @@ export class Validator {
                             if (match) {
                                 if (match[7]) {
                                     const protocol = match[7].toLowerCase();
-                                    if (protocol !== "" && protocol !== "tcp" && protocol !== "udp") {
+                                    if (protocol !== "" && protocol !== "tcp" && protocol !== "udp" && protocol !== "sctp") {
                                         const range = exposeArgs[i].getRange();
                                         const rangeStart = this.document.offsetAt(range.start);
                                         const rawArg = this.document.getText().substring(

--- a/test/dockerValidator.test.ts
+++ b/test/dockerValidator.test.ts
@@ -2472,6 +2472,8 @@ describe("Docker Validator Tests", function() {
                 testValidArgument("EXPOSE", "8080/TcP");
                 testValidArgument("EXPOSE", "8080/udp");
                 testValidArgument("EXPOSE", "8080/uDp");
+                testValidArgument("EXPOSE", "8080/sctp");
+                testValidArgument("EXPOSE", "8080/sCTp");
                 testValidArgument("EXPOSE", "8080:8080");
                 testValidArgument("EXPOSE", "8080:8080/tcp");
                 // unspecified protocol is assumed to be TCP


### PR DESCRIPTION
Docker 18.03 [added support for exposing SCTP ports for a container](https://github.com/moby/moby/issues/9689)

This PR updates the validator to recognise `EXPOSE 8080/sctp` as valid.

Please let me know if I've missed anything.

