### PR TITLE
fix(validator): accept . , .. , and relative paths as COPY/ADD destination

### DIFF
--- a/src/dockerValidator.ts
+++ b/src/dockerValidator.ts
@@ -847,9 +847,9 @@ export class Validator {
             }
             const destination = lastArg.getValue();
             const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
-            const isCurrentDir = destinationNormalized === '.' || destinationNormalized === './';
+            const isCurrentOrParentDir = destinationNormalized === '.' || destinationNormalized === './' || destinationNormalized === '..' || destinationNormalized === '../';
             const lastChar = destination.charAt(destination.length - 1);
-            if (!isCurrentDir && lastChar !== '\\' && lastChar !== '/') {
+            if (!isCurrentOrParentDir && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, lastArg.getRange());
             }
         }
@@ -912,9 +912,9 @@ export class Validator {
             }
             const destination = lastJsonString.getValue();
             const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
-            const isCurrentDir = destinationNormalized === '.' || destinationNormalized === './';
+            const isCurrentOrParentDir = destinationNormalized === '.' || destinationNormalized === './' || destinationNormalized === '..' || destinationNormalized === '../';
             const lastChar = destination.charAt(destination.length - 2);
-            if (!isCurrentDir && lastChar !== '\\' && lastChar !== '/') {
+            if (!isCurrentOrParentDir && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, jsonStrings[jsonStrings.length - 1].getJSONRange());
             }
         }

--- a/src/dockerValidator.ts
+++ b/src/dockerValidator.ts
@@ -847,7 +847,7 @@ export class Validator {
             }
             const destination = lastArg.getValue();
             const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
-            const isRelativeDir = /^(\.\.?\/)*\.\.?\/?$/.test(destinationNormalized);
+            const isRelativeDir = /^(\.\.?[\/\\])*\.\.?[\/\\]?$/.test(destinationNormalized);
             const lastChar = destination.charAt(destination.length - 1);
             if (!isRelativeDir && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, lastArg.getRange());
@@ -912,7 +912,7 @@ export class Validator {
             }
             const destination = lastJsonString.getValue();
             const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
-            const isRelativeDir = /^(\.\.?\/)*\.\.?\/?$/.test(destinationNormalized);
+            const isRelativeDir = /^(\.\.?[\/\\])*\.\.?[\/\\]?$/.test(destinationNormalized);
             const lastChar = destination.charAt(destination.length - 2);
             if (!isRelativeDir && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, jsonStrings[jsonStrings.length - 1].getJSONRange());

--- a/src/dockerValidator.ts
+++ b/src/dockerValidator.ts
@@ -846,8 +846,10 @@ export class Validator {
                 }
             }
             const destination = lastArg.getValue();
+            const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
+            const isCurrentDir = destinationNormalized === '.' || destinationNormalized === './';
             const lastChar = destination.charAt(destination.length - 1);
-            if (lastChar !== '\\' && lastChar !== '/') {
+            if (!isCurrentDir && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, lastArg.getRange());
             }
         }
@@ -909,8 +911,10 @@ export class Validator {
                 }
             }
             const destination = lastJsonString.getValue();
+            const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
+            const isCurrentDir = destinationNormalized === '.' || destinationNormalized === './';
             const lastChar = destination.charAt(destination.length - 2);
-            if (lastChar !== '\\' && lastChar !== '/') {
+            if (!isCurrentDir && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, jsonStrings[jsonStrings.length - 1].getJSONRange());
             }
         }

--- a/src/dockerValidator.ts
+++ b/src/dockerValidator.ts
@@ -847,9 +847,9 @@ export class Validator {
             }
             const destination = lastArg.getValue();
             const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
-            const isCurrentOrParentDir = destinationNormalized === '.' || destinationNormalized === './' || destinationNormalized === '..' || destinationNormalized === '../';
+            const isRelativeDir = /^(\.\.?\/)*\.\.?\/?$/.test(destinationNormalized);
             const lastChar = destination.charAt(destination.length - 1);
-            if (!isCurrentOrParentDir && lastChar !== '\\' && lastChar !== '/') {
+            if (!isRelativeDir && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, lastArg.getRange());
             }
         }
@@ -912,9 +912,9 @@ export class Validator {
             }
             const destination = lastJsonString.getValue();
             const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
-            const isCurrentOrParentDir = destinationNormalized === '.' || destinationNormalized === './' || destinationNormalized === '..' || destinationNormalized === '../';
+            const isRelativeDir = /^(\.\.?\/)*\.\.?\/?$/.test(destinationNormalized);
             const lastChar = destination.charAt(destination.length - 2);
-            if (!isCurrentOrParentDir && lastChar !== '\\' && lastChar !== '/') {
+            if (!isRelativeDir && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, jsonStrings[jsonStrings.length - 1].getJSONRange());
             }
         }

--- a/src/dockerValidator.ts
+++ b/src/dockerValidator.ts
@@ -55,6 +55,10 @@ const PREDEFINED_VARIABLES = [
 
 export class Validator {
 
+    private static readonly IS_RELATIVE_DIR = /^(\.\.?[\/\\])*\.\.?[\/\\]?$/;
+    private static readonly IS_PATH_WITH_DIR_NAMES = /^[\/\\]?(\.\.?|[^/\\]+)([\/\\](\.\.?|[^/\\]+))*[\/\\]?$/;
+    private static readonly ENDS_WITH_DIR_INDICATOR = /[\/\\]$|[\/\\]\.\.?[\/\\]?$/;
+
     private document: TextDocument;
 
     private settings: ValidatorSettings = {
@@ -818,6 +822,13 @@ export class Validator {
         return args[args.length - 1];
     }
 
+    private isValidDirectoryDestination(destinationNormalized: string): boolean {
+        const isRelativeDir = Validator.IS_RELATIVE_DIR.test(destinationNormalized);
+        const isPathWithDirNames = Validator.IS_PATH_WITH_DIR_NAMES.test(destinationNormalized);
+        const endsWithDirIndicator = Validator.ENDS_WITH_DIR_INDICATOR.test(destinationNormalized);
+        return isRelativeDir || (isPathWithDirNames && endsWithDirIndicator);
+    }
+
     private checkDestinationIsDirectory(instruction: JSONInstruction, requiresTwoArgumentsFunction: (instructionLine: uinteger, range: Range) => Diagnostic, notDirectoryFunction: (instructionLine: uinteger, range: Range) => Diagnostic): Diagnostic | null {
         if (instruction.getClosingBracket()) {
             return this.checkJsonDestinationIsDirectory(instruction, requiresTwoArgumentsFunction, notDirectoryFunction);
@@ -847,9 +858,8 @@ export class Validator {
             }
             const destination = lastArg.getValue();
             const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
-            const isRelativeDir = /^(\.\.?[\/\\])*\.\.?[\/\\]?$/.test(destinationNormalized);
             const lastChar = destination.charAt(destination.length - 1);
-            if (!isRelativeDir && lastChar !== '\\' && lastChar !== '/') {
+            if (!this.isValidDirectoryDestination(destinationNormalized) && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, lastArg.getRange());
             }
         }
@@ -912,9 +922,8 @@ export class Validator {
             }
             const destination = lastJsonString.getValue();
             const destinationNormalized = destination.trim().replace(/^["']+|["']+$/g, '');
-            const isRelativeDir = /^(\.\.?[\/\\])*\.\.?[\/\\]?$/.test(destinationNormalized);
             const lastChar = destination.charAt(destination.length - 2);
-            if (!isRelativeDir && lastChar !== '\\' && lastChar !== '/') {
+            if (!this.isValidDirectoryDestination(destinationNormalized) && lastChar !== '\\' && lastChar !== '/') {
                 return notDirectoryFunction(instruction.getInstructionRange().start.line, jsonStrings[jsonStrings.length - 1].getJSONRange());
             }
         }

--- a/test/dockerValidator.test.ts
+++ b/test/dockerValidator.test.ts
@@ -2227,6 +2227,14 @@ describe("Docker Validator Tests", function() {
                 diagnostics = validateDockerfile("FROM alpine\nADD [ \"file1\", \"file2\", \"file3\", \"./\" ]");
                 assert.equal(diagnostics.length, 0);
             });
+
+            it("multiple sources with destination .. or ../ do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 ..");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 ../");
+                assert.equal(diagnostics.length, 0);
+            });
         });
 
         describe("flags", function() {
@@ -2816,6 +2824,14 @@ describe("Docker Validator Tests", function() {
                 assert.equal(diagnostics.length, 0);
 
                 diagnostics = validateDockerfile("FROM alpine\nCOPY [ \"file1\", \"file2\", \"file3\", \"./\" ]");
+                assert.equal(diagnostics.length, 0);
+            });
+
+            it("multiple sources with destination .. or ../ do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 file3 ..");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 file3 ../");
                 assert.equal(diagnostics.length, 0);
             });
         });

--- a/test/dockerValidator.test.ts
+++ b/test/dockerValidator.test.ts
@@ -2265,6 +2265,11 @@ describe("Docker Validator Tests", function() {
                 diagnostics = validateDockerfile("#escape=`\nFROM alpine\nADD file1 file2 ..\\");
                 assert.equal(diagnostics.length, 0);
             });
+
+            it("destination with leading slash or path segments (e.g. /.././../directory1/.) do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 /.././../directory1/.");
+                assert.equal(diagnostics.length, 0);
+            });
         });
 
         describe("flags", function() {
@@ -2886,6 +2891,14 @@ describe("Docker Validator Tests", function() {
                 assert.equal(diagnostics.length, 0);
 
                 diagnostics = validateDockerfile("#escape=`\nFROM alpine\nCOPY file1 file2 ..\\");
+                assert.equal(diagnostics.length, 0);
+            });
+
+            it("destination with leading slash or path segments (e.g. /.././../directory1/.) do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 /.././../directory1/.");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nCOPY [ \"file1\", \"file2\", \"/.././../directory1/.\" ]");
                 assert.equal(diagnostics.length, 0);
             });
         });

--- a/test/dockerValidator.test.ts
+++ b/test/dockerValidator.test.ts
@@ -2234,6 +2234,12 @@ describe("Docker Validator Tests", function() {
 
                 diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 ../");
                 assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nADD [ \"file1\", \"file2\", \"file3\", \"..\" ]");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nADD [ \"file1\", \"file2\", \"file3\", \"../\" ]");
+                assert.equal(diagnostics.length, 0);
             });
 
             it("destination with trailing slash (./ and ../) accepted so relative-dir regex does not regress", function() {
@@ -2249,6 +2255,14 @@ describe("Docker Validator Tests", function() {
                 assert.equal(diagnostics.length, 0);
 
                 diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 ../../");
+                assert.equal(diagnostics.length, 0);
+            });
+
+            it("relative paths with backslash (Windows-style) do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("#escape=`\nFROM alpine\nADD file1 file2 ..\\..");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("#escape=`\nFROM alpine\nADD file1 file2 ..\\");
                 assert.equal(diagnostics.length, 0);
             });
         });
@@ -2864,6 +2878,14 @@ describe("Docker Validator Tests", function() {
                 assert.equal(diagnostics.length, 0);
 
                 diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 file3 ../../");
+                assert.equal(diagnostics.length, 0);
+            });
+
+            it("relative paths with backslash (Windows-style) do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("#escape=`\nFROM alpine\nCOPY file1 file2 ..\\..");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("#escape=`\nFROM alpine\nCOPY file1 file2 ..\\");
                 assert.equal(diagnostics.length, 0);
             });
         });

--- a/test/dockerValidator.test.ts
+++ b/test/dockerValidator.test.ts
@@ -2235,6 +2235,22 @@ describe("Docker Validator Tests", function() {
                 diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 ../");
                 assert.equal(diagnostics.length, 0);
             });
+
+            it("destination with trailing slash (./ and ../) accepted so relative-dir regex does not regress", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 ./");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 ../");
+                assert.equal(diagnostics.length, 0);
+            });
+
+            it("deeper relative paths ../.. and ../../ do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 ../..");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 ../../");
+                assert.equal(diagnostics.length, 0);
+            });
         });
 
         describe("flags", function() {
@@ -2832,6 +2848,22 @@ describe("Docker Validator Tests", function() {
                 assert.equal(diagnostics.length, 0);
 
                 diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 file3 ../");
+                assert.equal(diagnostics.length, 0);
+            });
+
+            it("destination with trailing slash (./ and ../) accepted so relative-dir regex does not regress", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 ./");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 ../");
+                assert.equal(diagnostics.length, 0);
+            });
+
+            it("deeper relative paths ../.. and ../../ do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 file3 ../..");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 file3 ../../");
                 assert.equal(diagnostics.length, 0);
             });
         });

--- a/test/dockerValidator.test.ts
+++ b/test/dockerValidator.test.ts
@@ -2213,6 +2213,20 @@ describe("Docker Validator Tests", function() {
                 assert.equal(diagnostics.length, 1);
                 assertADDDestinationNotDirectory(diagnostics[0], 2, 2, 33, 2, 39);
             });
+
+            it("multiple sources with destination . or ./ do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 .");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nADD file1 file2 file3 ./");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nADD [ \"file1\", \"file2\", \"file3\", \".\" ]");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nADD [ \"file1\", \"file2\", \"file3\", \"./\" ]");
+                assert.equal(diagnostics.length, 0);
+            });
         });
 
         describe("flags", function() {
@@ -2789,6 +2803,20 @@ describe("Docker Validator Tests", function() {
                 diagnostics = validateDockerfile("#escape=`\nFROM microsoft/nanoserver\nCOPY [\"Dockerfile\",\"Dockerfile2\",\"C:\\tmp\" ]");
                 assert.equal(diagnostics.length, 1);
                 assertCOPYDestinationNotDirectory(diagnostics[0], 2, 2, 34, 2, 40);
+            });
+
+            it("multiple sources with destination . or ./ do not produce invalidDestination", function() {
+                let diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 file3 .");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nCOPY file1 file2 file3 ./");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nCOPY [ \"file1\", \"file2\", \"file3\", \".\" ]");
+                assert.equal(diagnostics.length, 0);
+
+                diagnostics = validateDockerfile("FROM alpine\nCOPY [ \"file1\", \"file2\", \"file3\", \"./\" ]");
+                assert.equal(diagnostics.length, 0);
             });
         });
 


### PR DESCRIPTION
Fixes the false positive where the validator reported `"When using COPY/ADD with more than one source file, the destination must be a directory and end with a / or a \"` for valid directory destinations.

On POSIX, `.` and `..` are the current and parent directories, so `COPY file1 file2 .`, `COPY file1 file2 ..`, and similar forms are valid. The Docker builder accepts them; per `VALIDATOR.md`, the validator should not error on Dockerfiles the builder can build.

### Changes
- **Current and parent directory:** Treat destination as valid when it is `.`, `./`, `..`, or `../` (after trimming and stripping optional surrounding quotes).
- **Deeper relative paths:** Use the regex `/^(\.\.?[\/\\])*\.\.?[\/\\]?$/` so any relative directory path is accepted (e.g. `../..`, `../../`, `.././../../.`), not only `.` and `..`.
- **Paths with directory names:** Treat destination as a directory when it is a path with one or more segments (e.g. `foo/`, `foo/bar/`, `a/b/c/`) and ends with `/` or `\`, using a path-segment regex plus an "ends with directory indicator" check.
- **Backslash (Windows-style):** The same logic allows `\` as path separator (e.g. `..\..`, `..\`, `foo\bar\`), consistent with the "end with `/` or `\`" rule.
- **Refactor:** Extract the directory-destination regexes into class-level constants (`IS_RELATIVE_DIR`, `IS_PATH_WITH_DIR_NAMES`, `ENDS_WITH_DIR_INDICATOR`) and a shared helper `isValidDirectoryDestination()`, used by both `checkDestinationIsDirectory` and `checkJsonDestinationIsDirectory`, removing duplicated logic.
- **Tests:**
  - `.` and `./` (shell and JSON) for `ADD` and `COPY`.
  - `..` and `../`.
  - Trailing-slash regression (`./` and `../`).
  - Deeper paths (`../..`, `../../`).
  - Backslash paths (`..\..`, `..\`) using `#escape=` so backslash is literal.

The `invalidDestination` message text is unchanged; only the condition that triggers it was relaxed.

### Testing note
I've tested paths like `../..` and `../../` on Docker (multi-source `COPY`/`ADD` with those destinations succeed).
I haven't run paths using backslash (e.g. `..\..`) 😅 ; the change is based on the documented rule that the destination may end with `\` and on the regex accepting the same relative-dir pattern with `\` as separator.

### Other Note
I'm not sure if too much for such a small fix -- I'd be happy to simplify to only the behavior change if so.